### PR TITLE
Create .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+rvm: 2.2
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y checkstyle
+install: 
+  - "gem install overcommit"
+script: 
+  - git config --global user.name "Fluid LA"
+  - git config --global user.email "fluidtest@la.com"
+  - "overcommit --sign"
+  - "overcommit --sign pre-commit"
+  - "cd challenges"
+  - "overcommit --run"


### PR DESCRIPTION
este es el archivo base para travis-ci. esta utilizando la misma configuracion de plugins y linters actual del archivo .overcommit.yml y .git-hooks
falta arreglar las dependencias para varios linters.