### PR TITLE
# Commit title: Implementing rust linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ group: edge
 python:
   - "2.7"
 
+rust:
+  - nightly
+
 go:
   - "1.7"
 
@@ -27,6 +30,7 @@ install:
   - sudo apt-get -y install hlint atom  -qq
   - sudo aptitude install shellcheck
   - sudo apm install linter-eastwood
+  - curl -sSf https://static.rust-lang.org/rustup.sh | sh
   - gem install cucumber ruby-lint
   - pip install scons requests flake8 https://github.com/google/closure-linter/zipball/master
 

--- a/site_scons/folders_builder.py
+++ b/site_scons/folders_builder.py
@@ -101,13 +101,15 @@ def lang_linters(fname):
     cpplint_conf = ["cpp lint", ["cppcheck"]]
     phplint_conf = ["php lint", ["php -l"]]
     golint_conf = ["go lint", ["golint"]]
+    rslint_conf = ["rust lint", ["rustc -D warnings"]]
     default_conf = ["skp"]
     # Init lint vars
     lint_vars = {"py": pylint_conf, "rb": rblint_conf,
                  "c": clint_conf, "js": jslint_conf,
                  "sh": shlint_conf, "java": jvlint_conf,
                  "hs": hslint_conf, "cpp": cpplint_conf,
-                 "php": phplint_conf, "go": golint_conf}
+                 "php": phplint_conf, "go": golint_conf,
+                 "rs": rslint_conf}
     # Extract ext
     fname_ext = os.path.splitext(fname.rstr())[1].translate(None, '.')
     # Get lint params


### PR DESCRIPTION
# Files changed:
	.travis.yml     -> install rustc.
	folders_builder -> add rust lint conf and dictionary entry.

# TODO
Fix clojure linters
Missing linters:
lua
pl
ocaml q es ml
y scala
Refactor lang_linters():
  - place lint_conf vars in a dict.
  - lint_vars = {"py": lint_conf_dict["py"]...}